### PR TITLE
ci: remove Azure App Service deployment steps

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Dev - Deploy
+name: Build
 
 on:
   push:
@@ -7,17 +7,15 @@ on:
   workflow_dispatch:
 
 jobs:
-  deploy_prd:
+  build:
     runs-on: ubuntu-latest
-    name: Deploy to dev App Service
-    environment:
-      name: 'Production'
+    name: Build backend
 
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
       with:
-        fetch-depth: 0 
+        fetch-depth: 0
 
     - name: Get the latest tag
       id: get_tag
@@ -26,7 +24,7 @@ jobs:
         latest_tag=$(git describe --tags --abbrev=0 || echo "v0.0.0")
         echo "Latest tag: $latest_tag"
         echo "latest_tag=$latest_tag" >> $GITHUB_ENV
-    
+
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
@@ -38,17 +36,3 @@ jobs:
     - name: Build
       run: |
         yarn build
-
-    - name: Prepare deployment package
-      run: |
-       mkdir cosmic-be
-       cp -r dist cosmic-be/
-       cp -r node_modules cosmic-be/
-      
-    - name: Deploy to Azure Web App
-      uses: azure/webapps-deploy@v2
-      with:
-        app-name: app-cosmic-dev-be-01
-        slot-name: production
-        publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
-        package: ./cosmic-be

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,11 +7,9 @@ on:
   workflow_dispatch:
 
 jobs:
-  deploy_prd:
+  build:
     runs-on: ubuntu-latest
-    name: Deploy to dev App Service
-    environment:
-      name: 'Production'
+    name: Build backend
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
Azure App Service (app-cosmic-dev-be-01) is no longer active. Removed the azure/webapps-deploy step, deployment package preparation, and Production environment reference to prevent workflow failures. Build steps are retained as CI checks.