### PR TITLE
docs: add 'Documentation' section and domain links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,15 @@
 Welcome! This guide will help you run the **Cosmic WebApp API Backend** on your local machine.  
 Even if you’re not a developer — just follow the steps carefully 👇
 
+## Documentation
+
+The backend domain is rooted in **Space**, the primary aggregate representing a digital environment and anchoring related entities, permissions, and integrations.
+
+- [Domain model (`Space` and related entities)](docs/domain-model.md)
+- [Architecture overview](docs/architecture.md)
+- [ER model v1 diagram](docs/diagrams/er-model-v1.md)
+- [Architecture context diagram](docs/diagrams/architecture-context.md)
+
 ---
 
 ## 🚀 How to Start the API Backend (Development Mode)


### PR DESCRIPTION
### Motivation
- Add top-level documentation links and a brief domain summary to make the backend's core concepts discoverable.

### Description
- Added a `Documentation` section to `README.md` including a short description of the `Space` domain and links to `docs/domain-model.md`, `docs/architecture.md`, `docs/diagrams/er-model-v1.md`, and `docs/diagrams/architecture-context.md`.

### Testing
- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69aafb6c8c088325b2212426dfc62695)