### PR TITLE
Validate CALLBACK_BASE_URL and CALLBACK_SECRET on startup (issue #26)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,5 +14,8 @@ GCP_PROJECT_ID=
 GCP_REGION=europe-west4
 GCS_3D_PIPELINE_BUCKET=cosmic-3d-pipeline
 WORKER_DOCKER_IMAGE=
+# Publicly reachable URL of this backend (used by the worker to post status updates)
+# Example: https://your-backend.example.com
 CALLBACK_BASE_URL=
+# Shared secret to authenticate worker callbacks – generate with: openssl rand -hex 32
 CALLBACK_SECRET=

--- a/app/resolvers/reconstructionResolver.js
+++ b/app/resolvers/reconstructionResolver.js
@@ -56,6 +56,12 @@ async function submitBatchJob(jobId, inputPath, supabaseUrl, supabaseKey) {
     );
   }
 
+  if (!CALLBACK_BASE_URL) {
+    throw new Error(
+      'CALLBACK_BASE_URL must be set to a publicly reachable URL so the worker can post status updates',
+    );
+  }
+
   const client = getBatchClient();
 
   const batchJobId = `recon-${jobId}-${Date.now()}`;

--- a/server.js
+++ b/server.js
@@ -4,7 +4,17 @@ const {
   SUPABASE_URL,
   SUPABASE_KEY,
   COOKIE_SECRET,
+  CALLBACK_BASE_URL,
+  CALLBACK_SECRET,
 } = process.env;
+
+const requiredEnvVars = { SUPABASE_URL, SUPABASE_KEY, COOKIE_SECRET, CALLBACK_BASE_URL, CALLBACK_SECRET };
+for (const [name, value] of Object.entries(requiredEnvVars)) {
+  if (!value) {
+    console.error(`Missing required environment variable: ${name}`);
+    process.exit(1);
+  }
+}
 
 const express = require('express');
 const cors = require('cors');


### PR DESCRIPTION
- server.js: add both vars to required-env-vars check so the server exits with a clear error if either is missing at startup
- reconstructionResolver.js: add an explicit guard before dispatching a GCP Batch job so a missing CALLBACK_BASE_URL fails loudly instead of silently passing an invalid URL to the worker
- .env.example: document purpose and how to generate CALLBACK_SECRET

https://claude.ai/code/session_01JFz7ZYzb6TThVBtcUC3iFx