### PR TITLE
fix: remove CALLBACK_BASE_URL/CALLBACK_SECRET from startup required c…

### DIFF
--- a/server.js
+++ b/server.js
@@ -8,7 +8,7 @@ const {
   CALLBACK_SECRET,
 } = process.env;
 
-const requiredEnvVars = { SUPABASE_URL, SUPABASE_KEY, COOKIE_SECRET, CALLBACK_BASE_URL, CALLBACK_SECRET };
+const requiredEnvVars = { SUPABASE_URL, SUPABASE_KEY, COOKIE_SECRET };
 for (const [name, value] of Object.entries(requiredEnvVars)) {
   if (!value) {
     console.error(`Missing required environment variable: ${name}`);


### PR DESCRIPTION
…heck

These vars are only needed when triggering 3D reconstruction jobs, not at server startup. This allows the service to boot without them (bootstrap problem: Cloud Run URL isn't known before first deploy).

https://claude.ai/code/session_01PswXHzivM15VKrsYXNXJz2